### PR TITLE
Remove redundant paragonie/sodium_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
         "ext-json": "*",
         "ratchet/pawl": "^0.4.1",
         "james-heinrich/getid3": "^1.9",
-        "phpseclib/phpseclib": "^3.0",
-        "paragonie/sodium_compat": "^2.0.1"
+        "phpseclib/phpseclib": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.3",


### PR DESCRIPTION
This package depends on `paragonie/sodium_compat: ^2.0.1`, but also `php: >= 8.1.0`. Since `libsodium` was added in PHP 7.2, the dependency on `paragonie/sodium_compat` seems redundant?